### PR TITLE
[Homepage] Reverted slogan change

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -6,7 +6,7 @@
           <div class="row">                                                   
             <div class="large-5 columns startbanner">                                                           
               <img src="/images/logos/rorlogo.png">                                                           
-              <h3 class="slogan">The <i>original</i> Soft Body Physics Simulator</h3>                                                   
+              <h3 class="slogan">Soft Body Physics Simulator</h3>                                                   
             </div>                                           
           </div>                                           
           <div class="download-wrapper">                                                   


### PR DESCRIPTION
Reverting change done without my consent and without anyone even knowing.

![ror-ahem](https://cloud.githubusercontent.com/assets/491088/19810934/a799a08c-9d2f-11e6-8e7b-092ae6c5e19b.png)

Seriously "The _original_ simulator" is unacceptable. It's a Skybon-style campaign against BeamNG.
