### PR TITLE
Use youtube-nocookie.com domain to embed trailer

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -73,7 +73,7 @@
         <li class="is-active orbit-slide">                                  
               
           <div class="flex-video">
-            <iframe width="1920" height="1080" frameborder="0" src="https://www.youtube.com/embed/bRbQ4OaljWs" allowfullscreen></iframe>
+            <iframe width="1920" height="1080" frameborder="0" src="https://www.youtube-nocookie.com/embed/bRbQ4OaljWs" allowfullscreen></iframe>
           </div>
         </li>                          
         <li class="orbit-slide">                                


### PR DESCRIPTION
By using youtube-nocookie.com (which is an official Youtube domain) the placement of cookies is delayed until the video is started. This is a minor improvement for privacy if people choose to not play the video.